### PR TITLE
throw an exception if PPI fails to parse code

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl-PrereqScanner
 
 {{$NEXT}}
+ - throw an exception if PPI fails to parse code
 
 0.101891  2010-09-05 15:31:49 America/New_York
  - add a core scanner for Test::More's done_testing

--- a/lib/Perl/PrereqScanner.pm
+++ b/lib/Perl/PrereqScanner.pm
@@ -55,11 +55,15 @@ sub BUILD {
 Given a string containing Perl source code, this method returns a
 Version::Requirements object describing the modules it requires.
 
+This method will throw an exception if PPI fails to parse the code.
+
 =cut
 
 sub scan_string {
   my ($self, $str) = @_;
   my $ppi = PPI::Document->new( \$str );
+  confess "PPI parse failed" unless defined $ppi;
+
   return $self->scan_ppi_document( $ppi );
 }
 
@@ -71,11 +75,15 @@ sub scan_string {
 Given a file path to a Perl document, this method returns a
 Version::Requirements object describing the modules it requires.
 
+This method will throw an exception if PPI fails to parse the code.
+
 =cut
 
 sub scan_file {
   my ($self, $path) = @_;
   my $ppi = PPI::Document->new( $path );
+  confess "PPI failed to parse '$path'" unless defined $ppi;
+
   return $self->scan_ppi_document( $ppi );
 }
 

--- a/t/autoprereq.t
+++ b/t/autoprereq.t
@@ -213,4 +213,14 @@ prereq_is(
   },
 );
 
+{
+    my $scanner = Perl::PrereqScanner->new;
+    try {
+        $scanner->scan_string(\"\x0");
+        fail('scan succeeded');
+    } catch {
+        like($_, qr/PPI parse failed/);
+    };
+}
+
 done_testing;


### PR DESCRIPTION
PPI parses a lot of random character sequences, but sometimes it fails.
Perl::PrereqScanner then throws obscure exceptions:

  $ perl -MPerl::PrereqScanner -e 'Perl::PrereqScanner->new->scan_string("\x0");'
  Can't call method "find" on an undefined value at /opt/local/lib/perl5/site_perl/5.8.9/Perl/PrereqScanner/Scanner/Perl5.pm line 14.

This patch makes Perl::PrereqScanner fail earlier and with more clear message. It also documents that 'scan_file' and 'scan_string' methods can throw exceptions.
