### PR TITLE
If PPI parsing fails, report PPI::Document->errstr

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl-PrereqScanner
 
 {{$NEXT}}
+ - if PPI parsing fails, include PPI::Document->errstr in error message
+   (Christopher J. Madsen)
 
 1.011     2012-03-07 13:08:49 Europe/Paris
   - require CPAN::Meta::Requirements 2.120630 and fix tests to reflect

--- a/lib/Perl/PrereqScanner.pm
+++ b/lib/Perl/PrereqScanner.pm
@@ -65,7 +65,7 @@ This method will throw an exception if PPI fails to parse the code.
 sub scan_string {
   my ($self, $str) = @_;
   my $ppi = PPI::Document->new( \$str );
-  confess "PPI parse failed" unless defined $ppi;
+  confess "PPI parse failed: " . PPI::Document->errstr unless defined $ppi;
 
   return $self->scan_ppi_document( $ppi );
 }
@@ -85,7 +85,8 @@ This method will throw an exception if PPI fails to parse the code.
 sub scan_file {
   my ($self, $path) = @_;
   my $ppi = PPI::Document->new( $path );
-  confess "PPI failed to parse '$path'" unless defined $ppi;
+  confess "PPI failed to parse '$path': " . PPI::Document->errstr
+      unless defined $ppi;
 
   return $self->scan_ppi_document( $ppi );
 }


### PR DESCRIPTION
This will make it easier to debug PPI issues.  I thought of this after seeing [RT#76648](https://rt.cpan.org/Ticket/Display.html?id=76648).
