### PR TITLE
with array of string doesn't work

### DIFF
--- a/t/autoprereq.t
+++ b/t/autoprereq.t
@@ -170,13 +170,16 @@ prereq_is(
   },
 );
 
-prereq_is(
-  'with ("With::QW1", "With::QW2");',
-  {
-    'With::QW1' => 0,
-    'With::QW2' => 0,
-  },
-);
+TODO2: {
+    local $TODO = 'with array of string';
+    prereq_is(
+        'with ("With::QW1", "With::QW2");',
+        {
+            'With::QW1' => 0,
+            'With::QW2' => 0,
+        },
+    );
+}
 
 prereq_is(
   'with "::Foo"',


### PR DESCRIPTION
This doesn't work :

with('a', 'b);

Should be :

{ a => 0, b => 0}
