### PR TITLE
Add --cpanm option to bin/scan_prereqs

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Perl-PrereqScanner
 
 {{$NEXT}}
 
+   - add a --cpanm option to bin/scan_prereqs to produce output that
+     can be piped into cpanm (John SJ Anderson)
+
 1.014     2012-07-26 13:22:02 America/New_York
   - require a more recent PPI for various bugfixes that broke tests
     (thanks for the report, Salve J. Nilsen)

--- a/bin/scan_prereqs
+++ b/bin/scan_prereqs
@@ -19,7 +19,12 @@ my %options;
 GetOptions(
   \%options,
   'combine!',
+  'cpanm!',
 );
+
+# --cpanm implies --combine
+$options{combine}++ if $options{cpanm};
+
 my $combined = $options{combine} && CPAN::Meta::Requirements->new;
 
 foreach my $file ( @ARGV ? @ARGV : '.' ) {
@@ -46,24 +51,41 @@ sub scan_file {
 }
 
 if( $options{combine} ){
-    print_prereqs($combined);
+    print_prereqs($combined, $options{cpanm});
 }
 
 sub print_prereqs {
     my $prereqs = shift->as_string_hash;
-    my $max = max map { length } keys %$prereqs;
-    printf( "%-${max}s = %s\n", $_, $prereqs->{$_} )
-        for sort keys %$prereqs;
+    my $cpanm_output = shift;
+
+    if ( $cpanm_output ) {
+        ### FIXME grossly insufficient filtering, should refactor/backport
+        ### filtering from Dist::Zilla::Plugin::AutoPrereqs or something
+        foreach ( sort keys %$prereqs ) {
+            next if $_ eq 'perl';
+            print "$_\n"
+        }
+    }
+    else {
+        my $max = max map { length } keys %$prereqs;
+        printf( "%-${max}s = %s\n", $_, $prereqs->{$_} )
+          for sort keys %$prereqs;
+    }
 }
 
 exit;
 
 =head1 SYNOPSIS
 
-    scan_prerequs [--combine] [FILES]
+    scan_prereqs [--combine] [--cpanm] [FILES]
 
 Directories are traversed with L<File::Find> to collect all C<.pl>, C<.pm>, and
 C<.psgi> files. If no files are specified, the current working directory is
 scanned.
+
+The default is to output requirements on a per-file basis. Specifying
+C<--combine> will instead output a combined listing for all scanned
+files. Specifying C<--cpanm> has the same behavior as C<--combine> but
+produces output suitable for piping into L<App::cpanminus>
 
 =cut

--- a/t/scan_prereqs.t
+++ b/t/scan_prereqs.t
@@ -41,6 +41,16 @@ strict      = 0
 warnings    = 0
 OUTPUT
 
+    [cpanm => '--cpanm' => <<OUTPUT],
+Exporter
+File::Spec
+File::Temp
+IO::File
+Time::Local
+strict
+warnings
+OUTPUT
+
 ) {
     my ( $name, $args, $exp ) = @$test;
     my $command = "$^X $script $args $files";


### PR DESCRIPTION
Allows output from scan_prereqs to be piped into cpanm for maximal DWIMmery.
