### PR TITLE
Added method scan_module()

### DIFF
--- a/lib/Perl/PrereqScanner.pm
+++ b/lib/Perl/PrereqScanner.pm
@@ -113,6 +113,27 @@ sub scan_ppi_document {
   return $req;
 }
 
+=method scan_module
+
+  my $prereqs = $scanner->scan_module( $module_name );
+
+Given the name of a module, eg C<'PPI::Document'>,
+this method returns a CPAN::Meta::Requirements object
+describing the modules it requires.
+
+=cut
+
+sub scan_module {
+  my ($self, $module_name) = @_;
+
+  require Module::Path;
+  if (defined(my $path = Module::Path::module_path($module_name))) {
+    return $self->scan_file($path);
+  }
+
+  confess "Failed to find file for module '$module_name'";
+}
+
 1;
 __END__
 
@@ -126,6 +147,7 @@ __END__
   my $prereqs = $scanner->scan_ppi_document( $ppi_doc );
   my $prereqs = $scanner->scan_file( $file_path );
   my $prereqs = $scanner->scan_string( $perl_code );
+  my $prereqs = $scanner->scan_module( $module_name );
 
 =head1 DESCRIPTION
 

--- a/t/scan-module.t
+++ b/t/scan-module.t
@@ -1,0 +1,67 @@
+#!perl
+use strict;
+use warnings;
+
+use Perl::PrereqScanner;
+use Try::Tiny;
+
+use Test::More;
+
+sub module_prereq_is {
+  my ($module_name, $want, $comment) = @_;
+  $comment ||= $module_name;
+
+  my $scanner = Perl::PrereqScanner->new;
+
+  # scan_ppi_document
+  try {
+    my $result  = $scanner->scan_module( $module_name );
+    is_deeply($result->as_string_hash, $want, $comment);
+  } catch {
+    fail("scanner died on: $comment");
+    diag($_);
+  };
+
+}
+
+# Test with some Core modules whose dependencies are unlikely to change (very often)
+
+module_prereq_is(
+  'Getopt::Std',
+  {
+    'Exporter' => 0,
+    'perl'     => '5.000',
+  },
+);
+
+module_prereq_is(
+  'Carp',
+  {
+    'Exporter' => 0,
+    'perl'     => '5.006',
+    'strict'   => 0,
+    'warnings' => 0,
+  },
+);
+
+# Test with ourself!
+
+module_prereq_is(
+  'Perl::PrereqScanner',
+  {
+    'CPAN::Meta::Requirements'      => '2.120630',
+    'List::Util'                    => 0,
+    'Module::Path'                  => 0,
+    'Moose'                         => 0,
+    'PPI'                           => '1.215',
+    'Params::Util'                  => 0,
+    'Perl::PrereqScanner::Scanner'  => 0,
+    'String::RewritePrefix'         => '0.005',
+    'namespace::autoclean'          => 0,
+    'perl'                          => '5.008',
+    'strict'                        => 0,
+    'warnings'                      => 0,
+  },
+);
+
+done_testing;


### PR DESCRIPTION
I've added a method scan_module(), which takes a method name.

It uses Module::Path to find the path for a local install of the module, if there is one, and then calls scan_file() on that.

I added a separate testsuite, based on your autoprereq.t - wasn't sure if you'd want another clause added to prereq_is()
