### PR TITLE
doc link

### DIFF
--- a/lib/Perl/PrereqScanner.pm
+++ b/lib/Perl/PrereqScanner.pm
@@ -183,4 +183,8 @@ constructing your PrereqScanner:
   # Use any stock scanners, plus Example:
   my $scanner = Perl::PrereqScanner->new({ extra_scanners => [ qw(Example) ] });
 
+=head1 SEE ALSO
+
+L<scan-perl-prereqs>, in this distribution, is a command-line interface to the scanner
+
 =cut


### PR DESCRIPTION
I'm always forgetting what the executable is called, and since it's not listed in `perldoc Perl::PrereqScanner`, I have to find a browser and look up the metacpan page. lame!
