### PR TITLE
Bump required PPI version to get rid of 1 MB size limit

### DIFF
--- a/lib/Perl/PrereqScanner.pm
+++ b/lib/Perl/PrereqScanner.pm
@@ -10,7 +10,7 @@ use Moose;
 use List::Util qw(max);
 use Params::Util qw(_CLASS);
 use Perl::PrereqScanner::Scanner;
-use PPI 1.215; # module_version, bug fixes
+use PPI 1.218; # module_version, bug fixes and no limit on input document size
 use String::RewritePrefix 0.005 rewrite => {
   -as => '__rewrite_scanner',
   prefixes => { '' => 'Perl::PrereqScanner::Scanner::', '=' => '' },

--- a/t/scan-module.t
+++ b/t/scan-module.t
@@ -33,7 +33,7 @@ module_prereq_is(
     'List::Util'                    => 0,
     'Module::Path'                  => 0,
     'Moose'                         => 0,
-    'PPI'                           => '1.215',
+    'PPI'                           => '1.218',
     'Params::Util'                  => 0,
     'Perl::PrereqScanner::Scanner'  => 0,
     'String::RewritePrefix'         => '0.005',


### PR DESCRIPTION
PPI 1.218 was released today and no longer has a size limit for parsing large files.
