### PR TITLE
check if file is a real file, not a directory, symlink. Also remove use lib "$Bin/../lib"

### DIFF
--- a/bin/scan-perl-prereqs
+++ b/bin/scan-perl-prereqs
@@ -6,9 +6,6 @@ use strict;
 use warnings;
 
 use File::Find;
-use File::Spec::Functions qw{ catdir updir };
-use FindBin qw{ $Bin };
-use lib catdir( $Bin, updir, 'lib' );
 
 use List::Util qw{ max };
 use Perl::PrereqScanner;

--- a/bin/scan_prereqs
+++ b/bin/scan_prereqs
@@ -6,9 +6,6 @@ use strict;
 use warnings;
 
 use File::Find;
-use File::Spec::Functions qw{ catdir updir };
-use FindBin qw{ $Bin };
-use lib catdir( $Bin, updir, 'lib' );
 
 use List::Util qw{ max };
 use Perl::PrereqScanner;


### PR DESCRIPTION
I have a repository with a symlink script.pl. The target does not exist when developing/testing.
scan-perl-prereqs dies in this repository.
Checking for -f fixes this.
