### PR TITLE
Fix scanning of "use aliased;" with no import arguments

### DIFF
--- a/lib/Perl/PrereqScanner/Scanner/Aliased.pm
+++ b/lib/Perl/PrereqScanner/Scanner/Aliased.pm
@@ -32,6 +32,7 @@ sub scan_for_prereqs {
         || $_->isa('PPI::Token::Quote')
         } $node->arguments;
 
+      next unless @args;
       my ($module) = $self->_q_contents($args[0]);
       $req->add_minimum($module => 0);
     }

--- a/t/autoprereq.t
+++ b/t/autoprereq.t
@@ -656,6 +656,13 @@ prereq_is(
   },
 );
 
+prereq_is(
+  q{use aliased;},
+  {
+    'aliased' => 0,
+  },
+);
+
 # rolsky says this is a problem case
 prereq_is(
   q{use Test::Requires 'Foo'},


### PR DESCRIPTION
Without this fix, scanning that code would result in:
Can't call method "isa" on an undefined value at .../Perl/PrereqScanner/Scanner.pm line 32.

It also made it impossible to use [AutoPrereqs] on the aliased module without excluding the test file that used this syntax. :)
